### PR TITLE
Lollipop implementation

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,1 +1,11 @@
-<manifest package="dev.niltsiar.easycrypt" />
+<manifest package="dev.niltsiar.easycrypt"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <application>
+    <provider
+      android:authorities="${applicationId}.easycryptinitprovider"
+      android:name=".EasyCryptInitProvider"
+      android:exported="false"
+      android:initOrder="900" />
+  </application>
+</manifest>

--- a/library/src/main/kotlin/dev/niltsiar/easycrypt/EasyCrypt.kt
+++ b/library/src/main/kotlin/dev/niltsiar/easycrypt/EasyCrypt.kt
@@ -9,6 +9,12 @@ import javax.crypto.spec.IvParameterSpec
 
 class EasyCrypt(private val keyStorage: KeyStorage = getKeyStorage()) {
 
+    companion object {
+
+        @JvmStatic
+        val instance: EasyCrypt by lazy { EasyCrypt() }
+    }
+
     fun encrypt(value: String): String {
         val cipher = Cipher.getInstance(keyStorage.encryptionTransformation)
         cipher.init(Cipher.ENCRYPT_MODE, keyStorage.getKey())

--- a/library/src/main/kotlin/dev/niltsiar/easycrypt/EasyCrypt.kt
+++ b/library/src/main/kotlin/dev/niltsiar/easycrypt/EasyCrypt.kt
@@ -38,7 +38,7 @@ internal fun getKeyStorage(): KeyStorage {
     return if (isMarshmallowOrGreater) {
         KeyStorageAndroidKeystore()
     } else {
-        TODO()
+        KeyStorageSharedPreferences(EasyCryptInitProvider.applicationContext)
     }
 }
 

--- a/library/src/main/kotlin/dev/niltsiar/easycrypt/EasyCryptInitProvider.kt
+++ b/library/src/main/kotlin/dev/niltsiar/easycrypt/EasyCryptInitProvider.kt
@@ -1,0 +1,50 @@
+package dev.niltsiar.easycrypt
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.ProviderInfo
+import android.database.Cursor
+import android.net.Uri
+
+class EasyCryptInitProvider : ContentProvider() {
+
+    companion object {
+
+        @JvmSynthetic
+        internal const val EMPTY_APPLICATION_ID_PROVIDER_AUTHORITY = "dev.niltsiar.easycrypt.easycryptinitprovider"
+
+        @JvmStatic
+        lateinit var applicationContext: Context
+            private set
+    }
+
+    override fun onCreate(): Boolean {
+        return context?.let {
+            applicationContext = it
+            true
+        } ?: false
+    }
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun query(uri: Uri, projection: Array<String>?, selection: String?, selectionArgs: Array<String>?, sortOrder: String?): Cursor? = null
+
+    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun attachInfo(context: Context?, info: ProviderInfo?) {
+        checkContentProviderAuthority(info)
+        super.attachInfo(context, info)
+    }
+
+    private fun checkContentProviderAuthority(info: ProviderInfo?) {
+        checkNotNull(info) { "EasyCryptInitProvider ProviderInfo cannot be null" }
+        check(EMPTY_APPLICATION_ID_PROVIDER_AUTHORITY != info.authority) {
+            "Incorrect provider authority in manifest. Most likely due to a missing applicationId variable in application's gradle script"
+        }
+    }
+}

--- a/library/src/main/kotlin/dev/niltsiar/easycrypt/KeyStorage.kt
+++ b/library/src/main/kotlin/dev/niltsiar/easycrypt/KeyStorage.kt
@@ -5,19 +5,19 @@ package dev.niltsiar.easycrypt
 import java.security.Key
 import java.security.KeyStore
 
-interface KeyStorage {
-    fun keyExists(): Boolean
-    fun generateKey()
-    fun getKey(): Key
-    val encryptionTransformation: String
-}
-
 @JvmSynthetic
 internal const val ANDROID_KEYSTORE: String = "AndroidKeyStore"
 @JvmSynthetic
 internal const val MASTER_KEY_ALIAS: String = "easy_crypt_master_key"
 @JvmSynthetic
 internal const val IV_SEPARATOR: String = "@"
+
+interface KeyStorage {
+    fun keyExists(): Boolean
+    fun generateKey()
+    fun getKey(): Key
+    val encryptionTransformation: String
+}
 
 @JvmSynthetic
 internal fun getKeyStore(): KeyStore {

--- a/library/src/main/kotlin/dev/niltsiar/easycrypt/KeyStorageAndroidKeystore.kt
+++ b/library/src/main/kotlin/dev/niltsiar/easycrypt/KeyStorageAndroidKeystore.kt
@@ -41,7 +41,13 @@ class KeyStorageAndroidKeystore : KeyStorage {
         keyGenerator.generateKey()
     }
 
-    override fun getKey(): Key = getKeyStore().getKey(MASTER_KEY_ALIAS, null)
+    override fun getKey(): Key {
+        val key = getKeyStore().getKey(MASTER_KEY_ALIAS, null)
+
+        checkNotNull(key) { "StoredKey should not be null" }
+
+        return key
+    }
 }
 
 @TargetApi(Build.VERSION_CODES.M)

--- a/library/src/main/kotlin/dev/niltsiar/easycrypt/KeyStorageAndroidKeystore.kt
+++ b/library/src/main/kotlin/dev/niltsiar/easycrypt/KeyStorageAndroidKeystore.kt
@@ -11,15 +11,15 @@ import javax.crypto.KeyGenerator
 
 @TargetApi(Build.VERSION_CODES.M)
 @JvmSynthetic
-internal const val ENCRYPTION_BLOCK_MODE: String = KeyProperties.BLOCK_MODE_CBC
+internal const val ANDROID_KEYSTORE_ENCRYPTION_ALGORITHM: String = KeyProperties.KEY_ALGORITHM_AES
 @TargetApi(Build.VERSION_CODES.M)
 @JvmSynthetic
-internal const val ENCRYPTION_ALGORITHM: String = KeyProperties.KEY_ALGORITHM_AES
+internal const val ANDROID_KEYSTORE_ENCRYPTION_BLOCK_MODE: String = KeyProperties.BLOCK_MODE_CBC
 @TargetApi(Build.VERSION_CODES.M)
 @JvmSynthetic
-internal const val ENCRYPTION_PADDING: String = KeyProperties.ENCRYPTION_PADDING_PKCS7
+internal const val ANDROID_KEYSTORE_ENCRYPTION_PADDING: String = KeyProperties.ENCRYPTION_PADDING_PKCS7
 @JvmSynthetic
-internal const val KEY_SIZE: Int = 256
+internal const val ANDROID_KEYSTORE_KEY_SIZE: Int = 256
 
 @TargetApi(Build.VERSION_CODES.M)
 class KeyStorageAndroidKeystore : KeyStorage {
@@ -30,12 +30,13 @@ class KeyStorageAndroidKeystore : KeyStorage {
         }
     }
 
-    override val encryptionTransformation: String = "$ENCRYPTION_ALGORITHM/$ENCRYPTION_BLOCK_MODE/$ENCRYPTION_PADDING"
+    override val encryptionTransformation: String =
+        "$ANDROID_KEYSTORE_ENCRYPTION_ALGORITHM/$ANDROID_KEYSTORE_ENCRYPTION_BLOCK_MODE/$ANDROID_KEYSTORE_ENCRYPTION_PADDING"
 
     override fun keyExists(): Boolean = getKeyStore().containsAlias(MASTER_KEY_ALIAS)
 
     override fun generateKey() {
-        val keyGenerator = KeyGenerator.getInstance(ENCRYPTION_ALGORITHM, ANDROID_KEYSTORE)
+        val keyGenerator = KeyGenerator.getInstance(ANDROID_KEYSTORE_ENCRYPTION_ALGORITHM, ANDROID_KEYSTORE)
         keyGenerator.init(createKeyGenParameterSpec(MASTER_KEY_ALIAS))
         keyGenerator.generateKey()
     }
@@ -48,9 +49,9 @@ class KeyStorageAndroidKeystore : KeyStorage {
 internal fun createKeyGenParameterSpec(keyAlias: String): KeyGenParameterSpec {
     val purpose = KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
     val builder = KeyGenParameterSpec.Builder(keyAlias, purpose)
-        .setBlockModes(ENCRYPTION_BLOCK_MODE)
-        .setEncryptionPaddings(ENCRYPTION_PADDING)
-        .setKeySize(KEY_SIZE)
+        .setBlockModes(ANDROID_KEYSTORE_ENCRYPTION_BLOCK_MODE)
+        .setEncryptionPaddings(ANDROID_KEYSTORE_ENCRYPTION_PADDING)
+        .setKeySize(ANDROID_KEYSTORE_KEY_SIZE)
 
     return builder.build()
 }

--- a/library/src/main/kotlin/dev/niltsiar/easycrypt/KeyStorageSharedPreferences.kt
+++ b/library/src/main/kotlin/dev/niltsiar/easycrypt/KeyStorageSharedPreferences.kt
@@ -1,0 +1,100 @@
+@file:JvmName("KeyStorageSharedPreferencesUtils")
+
+package dev.niltsiar.easycrypt
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.security.KeyPairGeneratorSpec
+import java.math.BigInteger
+import java.security.Key
+import java.security.KeyPairGenerator
+import java.security.spec.AlgorithmParameterSpec
+import java.util.Calendar
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.security.auth.x500.X500Principal
+
+@JvmSynthetic
+internal const val RSA_ALGORITHM: String = "RSA"
+@JvmSynthetic
+internal const val RSA_BLOCK_MODE: String = "ECB"
+@JvmSynthetic
+internal const val RSA_PADDING: String = "PKCS1Padding"
+@JvmSynthetic
+internal const val RSA_KEY_SIZE: Int = 2048
+@JvmSynthetic
+internal const val RSA_TRANSFORMATION: String = "$RSA_ALGORITHM/$RSA_BLOCK_MODE/$RSA_PADDING"
+@JvmSynthetic
+internal const val AES_ALGORITHM: String = "AES"
+@JvmSynthetic
+internal const val AES_BLOCK_MODE: String = "CBC"
+@JvmSynthetic
+internal const val AES_PADDING: String = "PKCS7Padding"
+@JvmSynthetic
+internal const val AES_KEY_SIZE: Int = 256
+@JvmSynthetic
+internal const val ENCRYPTION_SHARED_PREFERENCES_NAME: String = "EasyCryptPreferences"
+
+class KeyStorageSharedPreferences(
+    private val context: Context,
+    private val sharedPreferences: SharedPreferences = context.getSharedPreferences(ENCRYPTION_SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
+) : KeyStorage {
+
+    init {
+        if (!keyExists()) {
+            generateKey()
+        }
+    }
+
+    override val encryptionTransformation: String = "$AES_ALGORITHM/$AES_BLOCK_MODE/$AES_PADDING"
+
+    override fun keyExists(): Boolean = getKeyStore().containsAlias(MASTER_KEY_ALIAS) && sharedPreferences.contains(MASTER_KEY_ALIAS)
+
+    override fun generateKey() {
+        val keyPairGenerator = KeyPairGenerator.getInstance(RSA_ALGORITHM, ANDROID_KEYSTORE)
+        keyPairGenerator.initialize(createKeyPairGenParameterSpec(context, MASTER_KEY_ALIAS))
+        val keyPair = keyPairGenerator.generateKeyPair()
+
+        val keyGenerator = KeyGenerator.getInstance(AES_ALGORITHM)
+        keyGenerator.init(AES_KEY_SIZE)
+        val secretKey = keyGenerator.generateKey()
+
+        val cipher = Cipher.getInstance(RSA_TRANSFORMATION)
+        cipher.init(Cipher.WRAP_MODE, keyPair.public)
+        val encrypytedKey = cipher.wrap(secretKey).toBase64()
+
+        sharedPreferences.edit().putString(MASTER_KEY_ALIAS, encrypytedKey).commit()
+    }
+
+    override fun getKey(): Key {
+        val encryptedKey = sharedPreferences.getString(MASTER_KEY_ALIAS, null)
+        checkNotNull(encryptedKey) { "StoredKey should not be null" }
+
+        val keyStore = getKeyStore()
+        val privateKey = keyStore.getKey(MASTER_KEY_ALIAS, null)
+
+        checkNotNull(privateKey) { "Certificate to decrypt secret key should not be null" }
+
+        val cipher = Cipher.getInstance(RSA_TRANSFORMATION)
+        cipher.init(Cipher.UNWRAP_MODE, privateKey)
+
+        return cipher.unwrap(encryptedKey.fromBase64(), AES_ALGORITHM, Cipher.SECRET_KEY)
+    }
+}
+
+@JvmSynthetic
+internal fun createKeyPairGenParameterSpec(context: Context, keyAlias: String): AlgorithmParameterSpec {
+    val startDate = Calendar.getInstance()
+    val endDate = Calendar.getInstance()
+    endDate.add(Calendar.YEAR, 100)
+
+    val builder = KeyPairGeneratorSpec.Builder(context)
+        .setAlias(keyAlias)
+        .setKeySize(RSA_KEY_SIZE)
+        .setSerialNumber(BigInteger.ONE)
+        .setSubject(X500Principal("CN=$keyAlias CA Certificate"))
+        .setStartDate(startDate.time)
+        .setEndDate(endDate.time)
+
+    return builder.build()
+}


### PR DESCRIPTION
This PR fixes #2 adding an implementation for Lollipop devices which stores the secret key using `SharedPreferences`, wrapping the AES key with an RSA key stored in the `AndroidKeyStore`